### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,19 @@ and this project adheres to
 ## [0.4.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.3.0...pace-rs-v0.4.0) - 2024-02-10
 
 ### Added
-- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
+
+- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command
+  ([#1](https://github.com/pace-rs/pace/pull/1))
 - *(core)* add core library
 - *(commands)* add commands skeleton
 
 ### Fixed
-- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io
+
+- *(manifest)* [**breaking**] use includes to only package the bare minimum for
+  crates.io
 
 ### Other
+
 - pace 0.3.0 / pace-core 0.2.0
 - pace 0.2.0 / pace-core 0.1.1
 - *(assets)* add logo to readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.3.0...pace-rs-v0.4.0) - 2024-02-10
+
+### Added
+- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
+- *(core)* add core library
+- *(commands)* add commands skeleton
+
+### Fixed
+- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io
+
+### Other
+- pace 0.3.0 / pace-core 0.2.0
+- pace 0.2.0 / pace-core 0.1.1
+- *(assets)* add logo to readme
+- fix order
+- add command overview
+- remove unneeded feature default
+- add deny.toml
+- remove outdated acceptance tests
+- rename pacers into pace
+- add justfile for dev
+- *(deps)* update dependencies
+- fmt
+- add build profiles
+- add dprint config
+- add more checks
+- add renovate.json
+- add cargo dist for releases
+- fix manifest
+- Fix Readme
+- Initial commit :rocket:
+
 ## [0.3.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.2.0...pace-rs-v0.3.0) - 2024-02-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pace-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "abscissa_core",
  "chrono",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-condvar-fair",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ pace_core = { path = "crates/core" }
 
 [package]
 name = "pace-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["the pace-rs team"]
 categories = ["command-line-utilities"]
 edition = "2021"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/pace-rs/pace/compare/pace_core-v0.2.0...pace_core-v0.3.0) - 2024-02-10
+
+### Added
+- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
+- *(core)* add core library
+
+### Fixed
+- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io
+
+### Other
+- pace 0.3.0 / pace-core 0.2.0
+- pace 0.2.0 / pace-core 0.1.1
+
 ## [0.2.0](https://github.com/pace-rs/pace/compare/pace_core-v0.1.1...pace_core-v0.2.0) - 2024-02-03
 
 ### Fixed

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -11,13 +11,18 @@ and this project adheres to
 ## [0.3.0](https://github.com/pace-rs/pace/compare/pace_core-v0.2.0...pace_core-v0.3.0) - 2024-02-10
 
 ### Added
-- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
+
+- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command
+  ([#1](https://github.com/pace-rs/pace/pull/1))
 - *(core)* add core library
 
 ### Fixed
-- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io
+
+- *(manifest)* [**breaking**] use includes to only package the bare minimum for
+  crates.io
 
 ### Other
+
 - pace 0.3.0 / pace-core 0.2.0
 - pace 0.2.0 / pace-core 0.1.1
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["the pace-rs team"]
 categories = ["command-line-utilities"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)
* `pace-rs`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `pace_core` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/function_missing.ron

Failed in:
  function pace_core::add, previously in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace_core\src\lib.rs:1
```

### ⚠️ `pace-rs` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/module_missing.ron

Failed in:
  mod pace_rs::config, previously in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace-rs\src\config.rs:1

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/pub_static_missing.ron

Failed in:
  APP in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace-rs\src\application.rs:11
  APP in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace-rs\src\application.rs:11

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/struct_missing.ron

Failed in:
  struct pace_rs::config::PaceConfig, previously in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace-rs\src\config.rs:12
  struct pace_rs::config::ExampleSection, previously in file C:\Users\dailyuse\AppData\Local\Temp\.tmpOCDuyv\pace-rs\src\config.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.3.0](https://github.com/pace-rs/pace/compare/pace_core-v0.2.0...pace_core-v0.3.0) - 2024-02-10

### Added
- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
- *(core)* add core library

### Fixed
- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io

### Other
- pace 0.3.0 / pace-core 0.2.0
- pace 0.2.0 / pace-core 0.1.1
</blockquote>

## `pace-rs`
<blockquote>

## [0.4.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.3.0...pace-rs-v0.4.0) - 2024-02-10

### Added
- *(commands)* [**breaking**] implement `begin`, `end`, and `now` command ([#1](https://github.com/pace-rs/pace/pull/1))
- *(core)* add core library
- *(commands)* add commands skeleton

### Fixed
- *(manifest)* [**breaking**] use includes to only package the bare minimum for crates.io

### Other
- pace 0.3.0 / pace-core 0.2.0
- pace 0.2.0 / pace-core 0.1.1
- *(assets)* add logo to readme
- fix order
- add command overview
- remove unneeded feature default
- add deny.toml
- remove outdated acceptance tests
- rename pacers into pace
- add justfile for dev
- *(deps)* update dependencies
- fmt
- add build profiles
- add dprint config
- add more checks
- add renovate.json
- add cargo dist for releases
- fix manifest
- Fix Readme
- Initial commit :rocket:
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).