### PR TITLE
test: implement more tests for ActivityStore and setup code coverage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+[build]
+rustdocflags = ["--document-private-items"]
+rustflags = "-C target-cpu=native -D warnings"
+# incremental = true
+
+[alias]
+xtask = "run --package xtask --"
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
+# [target.x86_64-apple-darwin]
+# rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
+
+# [target.x86_64-unknown-linux-gnu]
+# linker = "/usr/bin/clang"
+# rustflags = ["-C", "link-arg=--ld-path=/usr/bin/mold"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 **/*.rs.bk
+*.profraw
+coverage/lcov.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +432,18 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
 
 [[package]]
 name = "either"
@@ -495,6 +518,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -817,6 +846,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "merge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+dependencies = [
+ "merge_derive",
+ "num-traits",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +944,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,12 +1008,14 @@ version = "0.7.0"
 dependencies = [
  "async-condvar-fair",
  "chrono",
+ "delegate",
  "directories",
  "displaydoc",
  "futures",
  "getset",
  "itertools",
  "log",
+ "merge",
  "rstest",
  "rusqlite",
  "serde",
@@ -1325,6 +1388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1924,6 +1997,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dialoguer",
+ "duct",
+ "eyre",
+ "fs_extra",
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/cli", "crates/core"]
+members = ["crates/cli", "crates/core", "xtask"]
 
 [workspace.package]
 authors = ["the pace-rs team"]
@@ -10,6 +10,8 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/pace-rs/pace"
 
 [workspace.dependencies]
+clap = { version = "4", features = ["env", "wrap_help", "derive"] }
+eyre = "0.6.12"
 pace_cli = { path = "crates/cli", version = "0" }
 pace_core = { path = "crates/core", version = "0" }
 
@@ -41,11 +43,11 @@ eula = false
 
 [dependencies]
 chrono = { version = "0.4.34", features = ["serde"] }
-clap = { version = "4", features = ["env", "wrap_help"] }
+clap = { workspace = true }
 clap_complete = "4.5.0"
 dialoguer = { version = "0.11.0", features = ["history", "fuzzy-select"] }
 directories = "5.0.1"
-eyre = "0.6.12"
+eyre = { workspace = true }
 human-panic = "1.2.3"
 pace_cli = { workspace = true }
 pace_core = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,12 +22,14 @@ include = [
 [dependencies]
 async-condvar-fair = "1.0.0"
 chrono = { version = "0.4.34", features = ["serde"] }
+delegate = "0.12.0"
 directories = "5.0.1"
 displaydoc = "0.2.4"
 futures = "0.3.30"
 getset = "0.1.2"
 itertools = "0.12.1"
 log = "0.4.20"
+merge = "0.1.0"
 rusqlite = { version = "0.30.0", features = ["bundled", "chrono", "uuid"] }
 serde = "1.0.196"
 serde_derive = "1.0.196"

--- a/crates/core/src/domain/intermission.rs
+++ b/crates/core/src/domain/intermission.rs
@@ -4,9 +4,9 @@ use chrono::{Local, NaiveDate, NaiveDateTime, NaiveTime};
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-use crate::domain::{activity::PaceDuration, status::ItemStatus, tag::Tag, task::TaskList};
+use crate::domain::{status::ItemStatus, tag::Tag, task::TaskList, time::PaceDuration};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct IntermissionPeriod {
     begin: NaiveDateTime,
     end: Option<NaiveDateTime>,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -110,8 +110,14 @@ pub enum ActivityLogErrorKind {
     NoCacheToSync,
     /// Cache not available
     CacheNotAvailable,
-    /// Activity with id {0} not found
+    /// Activity with id '{0}' not found
     ActivityNotFound(ActivityId),
+    /// Activity with id '{0}' can't be removed from the activity log
+    ActivityCantBeRemoved(usize),
+    /// This activity has no id
+    ActivityIdNotSet,
+    /// Activity with id '{0}' already in use, can't create a new activity with the same id
+    ActivityIdAlreadyInUse(ActivityId),
 }
 
 trait PaceErrorMarker: Error {}

--- a/crates/core/src/service/activity_store.rs
+++ b/crates/core/src/service/activity_store.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
 use chrono::{NaiveDateTime, NaiveTime};
 use serde_derive::{Deserialize, Serialize};
@@ -25,8 +25,10 @@ pub struct ActivityStore {
     storage: Box<dyn ActivityStorage>,
 }
 
+/// TODO: Optimization for later to make lookup faster
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct ActivityStoreCache {
+    activity_ids: HashSet<ActivityId>,
     activities_by_id: BTreeMap<ActivityId, Activity>,
     last_entries: VecDeque<ActivityId>,
 }
@@ -55,7 +57,7 @@ impl SyncStorage for ActivityStore {
 }
 
 impl ActivityReadOps for ActivityStore {
-    fn read_activity(&self, activity_id: ActivityId) -> PaceResult<Option<Activity>> {
+    fn read_activity(&self, activity_id: ActivityId) -> PaceResult<Activity> {
         self.storage.read_activity(activity_id)
     }
 
@@ -72,11 +74,11 @@ impl ActivityWriteOps for ActivityStore {
         self.storage.create_activity(activity)
     }
 
-    fn update_activity(&self, activity_id: ActivityId, activity: Activity) -> PaceResult<()> {
+    fn update_activity(&self, activity_id: ActivityId, activity: Activity) -> PaceResult<Activity> {
         self.storage.update_activity(activity_id, activity)
     }
 
-    fn delete_activity(&self, activity_id: ActivityId) -> PaceResult<Option<Activity>> {
+    fn delete_activity(&self, activity_id: ActivityId) -> PaceResult<Activity> {
         self.storage.delete_activity(activity_id)
     }
 }

--- a/crates/core/src/storage/file.rs
+++ b/crates/core/src/storage/file.rs
@@ -7,10 +7,9 @@ use std::{
 };
 
 use chrono::{Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, SubsecRound};
+use itertools::Itertools;
 use toml;
 use uuid::Uuid;
-
-use itertools::Itertools;
 
 use crate::{
     domain::{
@@ -124,7 +123,7 @@ impl ActivityStorage for TomlActivityStorage {
 }
 
 impl ActivityReadOps for TomlActivityStorage {
-    fn read_activity(&self, activity_id: ActivityId) -> PaceResult<Option<Activity>> {
+    fn read_activity(&self, activity_id: ActivityId) -> PaceResult<Activity> {
         self.cache.read_activity(activity_id)
     }
 
@@ -166,11 +165,11 @@ impl ActivityWriteOps for TomlActivityStorage {
         self.cache.create_activity(activity)
     }
 
-    fn update_activity(&self, activity_id: ActivityId, activity: Activity) -> PaceResult<()> {
+    fn update_activity(&self, activity_id: ActivityId, activity: Activity) -> PaceResult<Activity> {
         self.cache.update_activity(activity_id, activity)
     }
 
-    fn delete_activity(&self, activity_id: ActivityId) -> PaceResult<Option<Activity>> {
+    fn delete_activity(&self, activity_id: ActivityId) -> PaceResult<Activity> {
         self.cache.delete_activity(activity_id)
     }
 }

--- a/crates/core/src/storage/in_memory.rs
+++ b/crates/core/src/storage/in_memory.rs
@@ -181,10 +181,6 @@ impl ActivityWriteOps for InMemoryActivityStorage {
 }
 
 impl ActivityStateManagement for InMemoryActivityStorage {
-    fn begin_activity(&self, activity: Activity) -> PaceResult<ActivityId> {
-        self.create_activity(activity)
-    }
-
     fn end_single_activity(
         &self,
         activity_id: ActivityId,

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -1,1 +1,11 @@
-
+/// Overwrite any value with another.
+///
+/// This can be used to overwrite an activity with another activity.
+///
+/// # Arguments
+///
+/// * `left` - The left value
+/// * `right` - The right value
+pub fn overwrite<T>(left: &mut T, right: T) {
+    *left = right;
+}

--- a/crates/core/tests/activity_store.rs
+++ b/crates/core/tests/activity_store.rs
@@ -1,0 +1,219 @@
+// Test the ActivityStore implementation with a InMemoryStorage backend.
+
+use pace_core::{domain::activity_log::ActivityLog, service::activity_store::ActivityStore};
+use pace_core::{
+    domain::{
+        activity::{Activity, ActivityId},
+        filter::ActivityFilter,
+    },
+    error::TestResult,
+    storage::{in_memory::InMemoryActivityStorage, ActivityReadOps, ActivityWriteOps},
+};
+
+use rstest::{fixture, rstest};
+
+#[fixture]
+fn activity_log_empty() -> ActivityLog {
+    let activities = vec![];
+
+    ActivityLog::from_iter(activities)
+}
+
+#[fixture]
+fn activity_log_with_content() -> (Vec<Activity>, ActivityLog) {
+    let activities = vec![
+        Activity::default(),
+        Activity::default(),
+        Activity::default(),
+        Activity::default(),
+        Activity::default(),
+        Activity::default(),
+    ];
+
+    (activities.clone(), ActivityLog::from_iter(activities))
+}
+
+#[fixture]
+fn activity_store_with_item(
+    activity_log_empty: ActivityLog,
+) -> TestResult<(ActivityId, Activity, ActivityStore)> {
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log_empty,
+    )));
+
+    let activity = Activity::builder()
+        .description("Test Description".to_string())
+        .category(Some("Test::Category".to_string()))
+        .build();
+
+    let activity_id = store.create_activity(activity.clone())?;
+
+    Ok((activity_id, activity, store))
+}
+
+#[rstest]
+fn test_activity_store_create_activity_passes(activity_log_empty: ActivityLog) -> TestResult<()> {
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log_empty,
+    )));
+
+    let activity = Activity::builder()
+        .description("Test Description".to_string())
+        .category(Some("Test::Category".to_string()))
+        .build();
+
+    let og_activity = activity.clone();
+    let og_activity_id = activity.id().expect("Activity ID should be set.");
+
+    let activity_id = store.create_activity(activity)?;
+
+    assert_eq!(activity_id, og_activity_id);
+
+    let stored_activity = store.read_activity(og_activity_id)?;
+
+    assert_eq!(stored_activity, og_activity);
+
+    Ok(())
+}
+
+#[rstest]
+fn test_activity_store_create_activity_fails(
+    activity_log_with_content: (Vec<Activity>, ActivityLog),
+) {
+    let (activities, activity_log) = activity_log_with_content;
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log,
+    )));
+
+    let id = activities[0].id().expect("Activity ID should be set.");
+
+    let activity = Activity::builder()
+        .id(id)
+        .description("Test Description".to_string())
+        .category(Some("Test::Category".to_string()))
+        .build();
+
+    assert!(store.create_activity(activity).is_err());
+}
+
+#[rstest]
+fn test_activity_store_read_activity_passes(
+    activity_store_with_item: TestResult<(ActivityId, Activity, ActivityStore)>,
+) -> TestResult<()> {
+    let (og_activity_id, og_activity, store) = activity_store_with_item?;
+
+    let stored_activity = store.read_activity(og_activity_id)?;
+
+    assert_eq!(stored_activity, og_activity);
+
+    Ok(())
+}
+
+#[rstest]
+fn test_activity_store_read_activity_fails(activity_log_empty: ActivityLog) {
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log_empty,
+    )));
+
+    let activity_id = ActivityId::default();
+
+    assert!(store.read_activity(activity_id).is_err());
+}
+
+// List activities can hardly fail, as it returns an empty list if no activities are found.
+// Therefore, we only test the success case. It would fail if the mutex is poisoned.
+#[rstest]
+fn test_activity_store_list_activities_passes(
+    activity_log_with_content: (Vec<Activity>, ActivityLog),
+) -> TestResult<()> {
+    let (activities, activity_log) = activity_log_with_content;
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log,
+    )));
+
+    let loaded_activities = store
+        .list_activities(ActivityFilter::Active)?
+        .expect("Should have activities.");
+
+    assert_eq!(
+        activities.len(),
+        loaded_activities.into_log().activities().len()
+    );
+
+    Ok(())
+}
+
+#[rstest]
+fn test_activity_store_update_activity_passes(
+    activity_store_with_item: TestResult<(ActivityId, Activity, ActivityStore)>,
+) -> TestResult<()> {
+    let (og_activity_id, og_activity, store) = activity_store_with_item?;
+
+    let updated_test_desc = "Updated Test Description".to_string();
+    let updated_test_cat = "Test::UpdatedCategory".to_string();
+
+    let mut new_activity = Activity::builder()
+        .description(updated_test_desc.to_string())
+        .category(Some(updated_test_cat))
+        .build();
+
+    let old_activity = store.update_activity(og_activity_id, new_activity.clone())?;
+
+    assert_eq!(old_activity, og_activity);
+
+    let stored_activity = store.read_activity(og_activity_id)?;
+
+    _ = new_activity.id_mut().replace(og_activity_id);
+
+    assert_eq!(stored_activity, new_activity);
+
+    Ok(())
+}
+
+#[rstest]
+fn test_activity_store_delete_activity_passes(
+    activity_store_with_item: TestResult<(ActivityId, Activity, ActivityStore)>,
+) -> TestResult<()> {
+    let (og_activity_id, og_activity, store) = activity_store_with_item?;
+
+    let activity = store.delete_activity(og_activity_id)?;
+
+    assert!(store.read_activity(og_activity_id).is_err());
+
+    assert_eq!(activity, og_activity);
+
+    Ok(())
+}
+
+#[rstest]
+fn test_activity_store_delete_activity_fails(
+    activity_log_with_content: (Vec<Activity>, ActivityLog),
+) {
+    let (_, activity_log) = activity_log_with_content;
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log,
+    )));
+
+    let activity_id = ActivityId::default();
+
+    assert!(store.delete_activity(activity_id).is_err());
+}
+
+#[rstest]
+fn test_activity_store_update_activity_fails(
+    activity_log_with_content: (Vec<Activity>, ActivityLog),
+) {
+    let (_, activity_log) = activity_log_with_content;
+    let store = ActivityStore::new(Box::new(InMemoryActivityStorage::new_with_activity_log(
+        activity_log,
+    )));
+
+    let new_activity = Activity::builder()
+        .description("test".to_string())
+        .category(Some("test".to_string()))
+        .build();
+
+    let activity_id = ActivityId::default();
+
+    assert!(store.update_activity(activity_id, new_activity).is_err());
+}

--- a/justfile
+++ b/justfile
@@ -122,3 +122,7 @@ inv-ft *ARGS:
 # prepare for making a PR
 pr:
 	just fmt lint test
+
+# Run the test suite with coverage for the given package
+coverage *ARGS: 
+	cargo tarpaulin --output-dir coverage/ -p {{ARGS}} -o Lcov

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,5 +17,29 @@ git_tag_enable = false
 # but we want to publish the crate to crates.io
 publish = true
 
+# only internal
+[[package]]
+name = "xtask"
+changelog_update = false
+git_release_enable = false
+git_tag_enable = false
+semver_check = false
+publish = false
+
 [changelog]
 protect_breaking_commits = true
+body = """
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+{% for commit in commits %}
+{%- if commit.scope -%}
+- *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+{% else -%}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{% endif -%}
+{% endfor -%}
+{% endfor %}"#;
+"""

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -92,12 +92,16 @@ pub struct EntryPoint {
     pub verbose: bool,
 
     /// Use the specified config file
-    #[arg(short, long)]
+    #[arg(short, long, env = "PACE_CONFIG_FILE")]
     pub config: Option<PathBuf>,
 
     /// Use the specified activity log file
-    #[arg(short, long)]
+    #[arg(short, long, env = "PACE_ACTIVITY_LOG_FILE")]
     pub activity_log_file: Option<PathBuf>,
+
+    /// Pace Home Directory
+    #[arg(long, env = "PACE_HOME")]
+    pub home: Option<PathBuf>,
 }
 
 impl Runnable for EntryPoint {

--- a/src/commands/begin.rs
+++ b/src/commands/begin.rs
@@ -86,7 +86,7 @@ impl BeginCmd {
 
         let activity = Activity::builder()
             .description(description.clone())
-            .begin(date_time)
+            .begin(date_time.into())
             .kind(ActivityKind::default())
             .category(category.clone())
             .build();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { workspace = true }
+dialoguer = "0.11.0"
+duct = "0.13.7"
+eyre = { workspace = true }
+fs_extra = "1.3.0"
+glob = "0.3.1"

--- a/xtask/src/helpers.rs
+++ b/xtask/src/helpers.rs
@@ -1,0 +1,92 @@
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use eyre::Result as AnyResult;
+use fs_extra as fsx;
+use fsx::dir::CopyOptions;
+use glob::glob;
+use std::path::{Path, PathBuf};
+
+///
+/// Remove a set of files given a glob
+///
+/// # Errors
+///
+/// Fails if listing or removal fails
+///
+pub fn clean_files(pattern: &str) -> AnyResult<()> {
+    let files: Result<Vec<PathBuf>, _> = glob(pattern)?.collect();
+    files?.iter().try_for_each(remove_file)
+}
+
+///
+/// Remove a single file
+///
+/// # Errors
+///
+/// Fails if removal fails
+///
+pub fn remove_file<P>(path: P) -> AnyResult<()>
+where
+    P: AsRef<Path>,
+{
+    fsx::file::remove(path).map_err(eyre::Error::msg)
+}
+
+///
+/// Remove a directory with its contents
+///
+/// # Errors
+///
+/// Fails if removal fails
+///
+pub fn remove_dir<P>(path: P) -> AnyResult<()>
+where
+    P: AsRef<Path>,
+{
+    fsx::dir::remove(path).map_err(eyre::Error::msg)
+}
+
+/// Check if path exists
+///
+pub fn exists<P>(path: P) -> bool
+where
+    P: AsRef<Path>,
+{
+    std::path::Path::exists(path.as_ref())
+}
+
+/// Copy entire folder contents
+///
+/// # Errors
+///
+/// Fails if file operations fail
+///
+pub fn copy_contents<P, Q>(from: P, to: Q, overwrite: bool) -> AnyResult<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+{
+    let mut opts = CopyOptions::new();
+    opts.content_only = true;
+    opts.overwrite = overwrite;
+    fsx::dir::copy(from, to, &opts).map_err(eyre::Error::msg)
+}
+
+/// Prompt the user to confirm an action
+///
+/// # Panics
+/// Panics if input interaction fails
+///
+pub fn confirm(question: &str) -> bool {
+    Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(question)
+        .interact()
+        .unwrap()
+}
+
+/// Gets the cargo root dir
+///
+pub fn root_dir() -> PathBuf {
+    let mut xtask_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    xtask_dir.pop();
+    xtask_dir
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod helpers;
+pub mod tasks;
+
+pub use tasks::install_deps::InstallationKind;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,67 @@
+#![allow(dead_code)]
+
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use xtask::InstallationKind;
+
+#[derive(Parser)]
+struct Xtask {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// generate code coverage report
+    Coverage {
+        /// generate html report
+        #[arg(long)]
+        html: bool,
+
+        /// run on complete workspace
+        #[arg(short, long)]
+        workspace: bool,
+
+        /// custom Cargo target directory
+        #[arg(short, long, value_parser = clap::value_parser!(PathBuf), env = "CARGO_TARGET_DIR")]
+        target_dir: Option<PathBuf>,
+    },
+    /// install dependencies
+    #[command(subcommand)]
+    InstallDeps(InstallationKind),
+    /// show longest times taken in release build using cargo-bloat
+    BloatTime {
+        #[arg(short = 'p', long, help = "package to build", required = true)]
+        package: Option<String>,
+    },
+    /// show biggest crates in release build using cargo-bloat
+    BloatDeps {
+        #[arg(short = 'p', long, help = "package to build", required = true)]
+        package: Option<String>,
+    },
+    /// show longest times taken in release build using cargo
+    Timings {
+        /// output timings as json
+        #[arg(short, long)]
+        json: bool,
+    },
+}
+
+fn main() -> Result<(), eyre::Error> {
+    let cli = Xtask::parse();
+
+    match cli.command {
+        Some(Commands::Coverage {
+            html,
+            workspace,
+            target_dir,
+        }) => xtask::tasks::coverage(html, workspace, target_dir)?,
+        Some(Commands::InstallDeps(kind)) => xtask::tasks::install_deps(kind)?,
+        Some(Commands::BloatTime { package }) => xtask::tasks::bloat_time(package)?,
+        Some(Commands::BloatDeps { package }) => xtask::tasks::bloat_deps(package)?,
+        Some(Commands::Timings { json }) => xtask::tasks::timings(json)?,
+        None => {}
+    }
+
+    Ok(())
+}

--- a/xtask/src/tasks.rs
+++ b/xtask/src/tasks.rs
@@ -1,0 +1,9 @@
+pub mod bloat;
+pub mod coverage;
+pub mod install_deps;
+pub mod timings;
+
+pub use bloat::{bloat_deps, bloat_time};
+pub use coverage::coverage;
+pub use install_deps::install_deps;
+pub use timings::timings;

--- a/xtask/src/tasks/bloat.rs
+++ b/xtask/src/tasks/bloat.rs
@@ -1,0 +1,28 @@
+//! Show crate build times
+
+use duct::cmd;
+use eyre::Result;
+
+/// Show longest times taken in release build
+///
+/// # Errors
+///
+/// Errors if the command failed
+///
+pub fn bloat_time(package: impl Into<Option<String>>) -> Result<()> {
+    let package = package.into().unwrap_or("rustic".to_string());
+    cmd!("cargo", "bloat", "--time", "-j", "1", "-p", package).run()?;
+    Ok(())
+}
+
+/// Show biggest crates in release build
+///
+/// # Errors
+///
+/// Errors if the command failed
+///
+pub fn bloat_deps(package: impl Into<Option<String>>) -> Result<()> {
+    let package = package.into().unwrap_or("rustic".to_string());
+    cmd!("cargo", "bloat", "--release", "--crates", "-p", package).run()?;
+    Ok(())
+}

--- a/xtask/src/tasks/coverage.rs
+++ b/xtask/src/tasks/coverage.rs
@@ -1,0 +1,81 @@
+use duct::cmd;
+use eyre::Result;
+use std::{fs::create_dir_all, path::PathBuf};
+
+pub fn coverage(
+    devmode: bool,
+    workspace: bool,
+    target_dir: impl Into<Option<PathBuf>>,
+) -> Result<()> {
+    let mut target_dir_new = target_dir.into().unwrap_or(PathBuf::from("./target"));
+    crate::helpers::remove_dir("coverage")?;
+    create_dir_all("coverage")?;
+
+    println!("=== running coverage ===");
+
+    let base_cmd = if workspace {
+        cmd!(
+            "cargo",
+            "test",
+            "--workspace",
+            "--target-dir",
+            target_dir_new.clone()
+        )
+    } else {
+        cmd!("cargo", "test", "--target-dir", target_dir_new.clone())
+    };
+
+    base_cmd
+        .env("CARGO_INCREMENTAL", "0")
+        .env("RUSTFLAGS", "-Cinstrument-coverage")
+        .env("LLVM_PROFILE_FILE", "cargo-test-%p-%m.profraw")
+        .run()?;
+    println!("ok.");
+
+    println!("=== generating report ===");
+    let (fmt, file) = if devmode {
+        ("html", "coverage/html")
+    } else {
+        ("lcov", "coverage/lcov.info")
+    };
+
+    target_dir_new = target_dir_new.join("debug").join("deps");
+
+    cmd!(
+        "grcov",
+        ".",
+        "--binary-path",
+        target_dir_new,
+        "-s",
+        ".",
+        "-t",
+        fmt,
+        "--branch",
+        "--ignore-not-existing",
+        "--ignore",
+        "../*",
+        "--ignore",
+        "/*",
+        "--ignore",
+        "xtask/*",
+        "--ignore",
+        "*/src/tests/*",
+        "-o",
+        file,
+    )
+    .run()?;
+    println!("ok.");
+
+    println!("=== cleaning up ===");
+    crate::helpers::clean_files("**/*.profraw")?;
+    println!("ok.");
+    if devmode {
+        if crate::helpers::confirm("open report folder?") {
+            cmd!("open", file).run()?;
+        } else {
+            println!("report location: {file}");
+        }
+    }
+
+    Ok(())
+}

--- a/xtask/src/tasks/install_deps.rs
+++ b/xtask/src/tasks/install_deps.rs
@@ -1,0 +1,65 @@
+use clap::Subcommand;
+use duct::cmd;
+use eyre::Result;
+
+#[derive(Subcommand, Debug, Clone, Copy)]
+pub enum InstallationKind {
+    /// only essential deps (cargo-bloat, llvm-tools-preview, grcov)
+    Essentials,
+    /// only code coverage deps (llvm-tools-preview, grcov)
+    CodeCoverage,
+    /// only mutation test deps (cargo-mutants)
+    Mutants,
+    /// only deps for fuzzing (cargo-fuzz)
+    Fuzzing,
+    /// only deps for (de-)bloating (cargo-bloat)
+    Bloat,
+    /// full deps (all of above)
+    Full,
+}
+
+/// Install cargo tools
+///
+/// # Errors
+///
+/// Errors if one of the commands failed
+///
+pub fn install_deps(kind: InstallationKind) -> Result<()> {
+    match kind {
+        InstallationKind::Essentials => {
+            install_essentials()?;
+            Ok(())
+        }
+        InstallationKind::Full => {
+            install_essentials()?;
+            cmd!("cargo", "install", "cargo-watch").run()?;
+            cmd!("cargo", "install", "cargo-hack").run()?;
+            cmd!("cargo", "install", "cargo-mutants").run()?;
+            Ok(())
+        }
+        InstallationKind::CodeCoverage => {
+            cmd!("rustup", "component", "add", "llvm-tools-preview").run()?;
+            cmd!("cargo", "install", "grcov").run()?;
+            Ok(())
+        }
+        InstallationKind::Mutants => {
+            cmd!("cargo", "install", "cargo-mutants").run()?;
+            Ok(())
+        }
+        InstallationKind::Fuzzing => {
+            cmd!("cargo", "install", "cargo-fuzz").run()?;
+            Ok(())
+        }
+        InstallationKind::Bloat => {
+            cmd!("cargo", "install", "cargo-bloat").run()?;
+            Ok(())
+        }
+    }
+}
+
+fn install_essentials() -> Result<()> {
+    cmd!("cargo", "install", "cargo-bloat").run()?;
+    cmd!("rustup", "component", "add", "llvm-tools-preview").run()?;
+    cmd!("cargo", "install", "grcov").run()?;
+    Ok(())
+}

--- a/xtask/src/tasks/timings.rs
+++ b/xtask/src/tasks/timings.rs
@@ -1,0 +1,15 @@
+use duct::cmd;
+use eyre::{Ok, Result};
+
+pub fn timings(json: bool) -> Result<()> {
+    let mut timings_str = String::from("--timings=");
+
+    if json {
+        timings_str.push_str("json")
+    } else {
+        timings_str.push_str("html")
+    }
+
+    cmd!("cargo", "build", "--release", timings_str).run()?;
+    Ok(())
+}


### PR DESCRIPTION
We need much better testing, to actually ease the burden of refactoring to different upcoming features. This is a first batch of tests implemented for the `ActivityStore` backed by an In-Memory Storage (for easier testing).