### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.9.0...pace-rs-v0.10.0) - 2024-02-28
+
+### Fixed
+- *(deps)* update rust crate log to 0.4.21 ([#57](https://github.com/pace-rs/pace/pull/57))
+
+### Other
+- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
+
 ## [0.9.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.8.2...pace-rs-v0.9.0) - 2024-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -432,7 +432,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -962,7 +962,7 @@ checksum = "f301c3f54f98abc6c212ee722f5e5c62e472a334415840669e356f04850051ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dialoguer",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1426,7 +1426,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.51",
+ "syn 2.0.52",
  "unicode-ident",
 ]
 
@@ -1522,7 +1522,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1626,7 +1626,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.51"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1749,7 +1749,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1906,7 +1906,7 @@ checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -2042,7 +2042,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2282,7 +2282,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.9.0"
+version = "0.10.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/pace-rs/pace/compare/pace_cli-v0.3.0...pace_cli-v0.4.0) - 2024-02-28
+
+### Other
+- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
+
 ## [0.3.0](https://github.com/pace-rs/pace/compare/pace_cli-v0.2.4...pace_cli-v0.3.0) - 2024-02-28
 
 ### Other

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.3.0"
+version = "0.4.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/pace-rs/pace/compare/pace_core-v0.11.0...pace_core-v0.12.0) - 2024-02-28
+
+### Fixed
+- *(deps)* update rust crate log to 0.4.21 ([#57](https://github.com/pace-rs/pace/pull/57))
+
+### Other
+- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
+
 ## [0.11.0](https://github.com/pace-rs/pace/compare/pace_core-v0.10.2...pace_core-v0.11.0) - 2024-02-28
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.11.0"
+version = "0.12.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `pace_core`: 0.11.0 -> 0.12.0 (⚠️ API breaking changes)
* `pace-rs`: 0.9.0 -> 0.10.0 (⚠️ API breaking changes)

### ⚠️ `pace_core` breaking changes

```
--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/pub_module_level_const_missing.ron

Failed in:
  PACE_ACTIVITY_LOG_FILENAME in file /tmp/.tmpMRdDTW/pace_core/src/lib.rs:13
  PACE_CONFIG_FILENAME in file /tmp/.tmpMRdDTW/pace_core/src/lib.rs:12
  PACE_CORE_VERSION in file /tmp/.tmpMRdDTW/pace_core/src/lib.rs:11

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct pace_core::SummaryCriteria, previously in file /tmp/.tmpMRdDTW/pace_core/src/domain/review.rs:176
  struct pace_core::ReviewOptions, previously in file /tmp/.tmpMRdDTW/pace_core/src/domain/review.rs:16
  struct pace_core::ReviewRequest, previously in file /tmp/.tmpMRdDTW/pace_core/src/domain/review.rs:143
```

### ⚠️ `pace-rs` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field NowCmd.now_opts in /tmp/.tmpUFRr4i/pace/src/commands/now.rs:14

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_missing.ron

Failed in:
  NowCmd::inner_run, previously in file /tmp/.tmpMRdDTW/pace-rs/src/commands/now.rs:30
  BeginCmd::inner_run, previously in file /tmp/.tmpMRdDTW/pace-rs/src/commands/begin.rs:57
  HoldCmd::inner_run, previously in file /tmp/.tmpMRdDTW/pace-rs/src/commands/hold.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.0](https://github.com/pace-rs/pace/compare/pace_cli-v0.3.0...pace_cli-v0.4.0) - 2024-02-28

### Other
- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
</blockquote>

## `pace_core`
<blockquote>

## [0.12.0](https://github.com/pace-rs/pace/compare/pace_core-v0.11.0...pace_core-v0.12.0) - 2024-02-28

### Fixed
- *(deps)* update rust crate log to 0.4.21 ([#57](https://github.com/pace-rs/pace/pull/57))

### Other
- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
</blockquote>

## `pace-rs`
<blockquote>

## [0.10.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.9.0...pace-rs-v0.10.0) - 2024-02-28

### Fixed
- *(deps)* update rust crate log to 0.4.21 ([#57](https://github.com/pace-rs/pace/pull/57))

### Other
- *(commands)* [**breaking**] Move a lot of the commands into pace-core ([#56](https://github.com/pace-rs/pace/pull/56))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).