### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.10.0...pace-rs-v0.11.0) - 2024-02-29
+
+### Added
+- *(commands)* implement adjust command and update readme accordingly
+- re-export pace libraries
+
+### Fixed
+- clippy
+
+### Other
+- *(activitylog)* do not pretty print to have collections (e.g., for tags) on one line
+- make just and dprint files hidden
+- update scoop manifest
+
 ## [0.10.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.9.0...pace-rs-v0.10.0) - 2024-02-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1072,7 +1072,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "dialoguer",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.10.0"
+version = "0.11.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.0...pace_cli-v0.4.1) - 2024-02-29
+
+### Fixed
+- clippy
+
 ## [0.4.0](https://github.com/pace-rs/pace/compare/pace_cli-v0.3.0...pace_cli-v0.4.0) - 2024-02-28
 
 ### Other

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.4.0"
+version = "0.4.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/pace-rs/pace/compare/pace_core-v0.12.0...pace_core-v0.12.1) - 2024-02-29
+
+### Added
+- *(commands)* implement adjust command and update readme accordingly
+
+### Fixed
+- clippy
+
+### Other
+- *(activitylog)* do not pretty print to have collections (e.g., for tags) on one line
+
 ## [0.12.0](https://github.com/pace-rs/pace/compare/pace_core-v0.11.0...pace_core-v0.12.0) - 2024-02-28
 
 ### Fixed

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.12.0"
+version = "0.12.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `pace_core`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `pace-rs`: 0.10.0 -> 0.11.0 (⚠️ API breaking changes)

### ⚠️ `pace-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_added.ron

Failed in:
  variant PaceCmd:Adjust in /tmp/.tmpRe36Ix/pace/src/commands.rs:37
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.1](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.0...pace_cli-v0.4.1) - 2024-02-29

### Fixed
- clippy
</blockquote>

## `pace_core`
<blockquote>

## [0.12.1](https://github.com/pace-rs/pace/compare/pace_core-v0.12.0...pace_core-v0.12.1) - 2024-02-29

### Added
- *(commands)* implement adjust command and update readme accordingly

### Fixed
- clippy

### Other
- *(activitylog)* do not pretty print to have collections (e.g., for tags) on one line
</blockquote>

## `pace-rs`
<blockquote>

## [0.11.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.10.0...pace-rs-v0.11.0) - 2024-02-29

### Added
- *(commands)* implement adjust command and update readme accordingly
- re-export pace libraries

### Fixed
- clippy

### Other
- *(activitylog)* do not pretty print to have collections (e.g., for tags) on one line
- make just and dprint files hidden
- update scoop manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).