### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.0...pace-rs-v0.11.1) - 2024-03-01
+
+### Fixed
+- create parent dir and activity and config file if --activity-log-file/--config is passed to pace but not existing
+- *(cli)* set aliases to subcommands to visible
+- phrasing in confirmation for not being able to resume ended activity
+- *(commands)* add short arg -s for begin --start
+- *(time)* actually test if begin time lies in the future, throwing an error that begin time cannot be after end time
+- *(command)* only set/override description when it actually contains a value
+
+### Other
+- remove version snapshot
+- fix snapshot testing for ci ([#62](https://github.com/pace-rs/pace/pull/62))
+- factor out begin command for keeping it dry
+- fix missing id for upload of snapshots
+- upload insta snapshots from failed ci runs
+- implement snapshot tests for cli output
+- *(deps)* lock file maintenance ([#61](https://github.com/pace-rs/pace/pull/61))
+- fix test for grouping activities fail on the boundary to midnight
+
 ## [0.11.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.10.0...pace-rs-v0.11.0) - 2024-02-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.11.0"
+version = "0.11.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/pace-rs/pace/compare/pace_core-v0.12.1...pace_core-v0.13.0) - 2024-03-01
+
+### Fixed
+- create parent dir and activity and config file if --activity-log-file/--config is passed to pace but not existing
+- *(commands)* add short arg -s for begin --start
+- *(time)* actually test if begin time lies in the future, throwing an error that begin time cannot be after end time
+- *(command)* only set/override description when it actually contains a value
+
+### Other
+- fix snapshot testing for ci ([#62](https://github.com/pace-rs/pace/pull/62))
+- fix test for grouping activities fail on the boundary to midnight
+
 ## [0.12.1](https://github.com/pace-rs/pace/compare/pace_core-v0.12.0...pace_core-v0.12.1) - 2024-02-29
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.12.1"
+version = "0.13.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.12.1 -> 0.13.0 (⚠️ API breaking changes)
* `pace-rs`: 0.11.0 -> 0.11.1 (✓ API compatible changes)

### ⚠️ `pace_core` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_missing.ron

Failed in:
  variant PaceErrorKind::ParsingTimeFromUserInputFailed, previously in file /tmp/.tmp4rVf99/pace_core/src/error.rs:105
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.13.0](https://github.com/pace-rs/pace/compare/pace_core-v0.12.1...pace_core-v0.13.0) - 2024-03-01

### Fixed
- create parent dir and activity and config file if --activity-log-file/--config is passed to pace but not existing
- *(commands)* add short arg -s for begin --start
- *(time)* actually test if begin time lies in the future, throwing an error that begin time cannot be after end time
- *(command)* only set/override description when it actually contains a value

### Other
- fix snapshot testing for ci ([#62](https://github.com/pace-rs/pace/pull/62))
- fix test for grouping activities fail on the boundary to midnight
</blockquote>

## `pace-rs`
<blockquote>

## [0.11.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.0...pace-rs-v0.11.1) - 2024-03-01

### Fixed
- create parent dir and activity and config file if --activity-log-file/--config is passed to pace but not existing
- *(cli)* set aliases to subcommands to visible
- phrasing in confirmation for not being able to resume ended activity
- *(commands)* add short arg -s for begin --start
- *(time)* actually test if begin time lies in the future, throwing an error that begin time cannot be after end time
- *(command)* only set/override description when it actually contains a value

### Other
- remove version snapshot
- fix snapshot testing for ci ([#62](https://github.com/pace-rs/pace/pull/62))
- factor out begin command for keeping it dry
- fix missing id for upload of snapshots
- upload insta snapshots from failed ci runs
- implement snapshot tests for cli output
- *(deps)* lock file maintenance ([#61](https://github.com/pace-rs/pace/pull/61))
- fix test for grouping activities fail on the boundary to midnight
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).