### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.1...pace-rs-v0.12.0) - 2024-03-02
+
+### Added
+- add opening documentation on configuration
+- *(commands)* [**breaking**] remove only-last option for end and replace --start/--end with --at/-a for setting times
+
+### Fixed
+- make sure, there are never any held activities without an active intermission
+- *(deps)* update rust crate open to 5.1.0 ([#63](https://github.com/pace-rs/pace/pull/63))
+
+### Other
+- reimplement logic to end and activity for in-memory storage to make it easier for error handling
+- check if activities to resume is none
+- add test for beginning activies on top of held ones
+- add comment about use cases still to test via cli
+- refactor tests to use results
+- use is_future validator for extract_time_or_now to make sure the user doesn't use times laying in the future
+- add doc comment to is_endable()
+
 ## [0.11.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.0...pace-rs-v0.11.1) - 2024-03-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1246,9 +1246,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1267,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -2209,9 +2209,9 @@ checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.11.1"
+version = "0.12.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/pace-rs/pace/compare/pace_core-v0.13.0...pace_core-v0.14.0) - 2024-03-02
+
+### Added
+- add opening documentation on configuration
+- *(commands)* [**breaking**] remove only-last option for end and replace --start/--end with --at/-a for setting times
+
+### Fixed
+- make sure, there are never any held activities without an active intermission
+- *(deps)* update rust crate open to 5.1.0 ([#63](https://github.com/pace-rs/pace/pull/63))
+
+### Other
+- reimplement logic to end and activity for in-memory storage to make it easier for error handling
+- check if activities to resume is none
+- add test for beginning activies on top of held ones
+- refactor tests to use results
+- use is_future validator for extract_time_or_now to make sure the user doesn't use times laying in the future
+- add doc comment to is_endable()
+
 ## [0.13.0](https://github.com/pace-rs/pace/compare/pace_core-v0.12.1...pace_core-v0.13.0) - 2024-03-01
 
 ### Fixed

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.13.0"
+version = "0.14.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.13.0 -> 0.14.0 (⚠️ API breaking changes)
* `pace-rs`: 0.11.1 -> 0.12.0 (✓ API compatible changes)

### ⚠️ `pace_core` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_missing.ron

Failed in:
  EndCommandOptions::end, previously in file /tmp/.tmpVP22r1/pace_core/src/commands/end.rs:12
  EndCommandOptions::only_last, previously in file /tmp/.tmpVP22r1/pace_core/src/commands/end.rs:12

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/trait_method_missing.ron

Failed in:
  method end_all_unfinished_activities of trait ActivityStateManagement, previously in file /tmp/.tmpVP22r1/pace_core/src/storage.rs:346
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.14.0](https://github.com/pace-rs/pace/compare/pace_core-v0.13.0...pace_core-v0.14.0) - 2024-03-02

### Added
- add opening documentation on configuration
- *(commands)* [**breaking**] remove only-last option for end and replace --start/--end with --at/-a for setting times

### Fixed
- make sure, there are never any held activities without an active intermission
- *(deps)* update rust crate open to 5.1.0 ([#63](https://github.com/pace-rs/pace/pull/63))

### Other
- reimplement logic to end and activity for in-memory storage to make it easier for error handling
- check if activities to resume is none
- add test for beginning activies on top of held ones
- refactor tests to use results
- use is_future validator for extract_time_or_now to make sure the user doesn't use times laying in the future
- add doc comment to is_endable()
</blockquote>

## `pace-rs`
<blockquote>

## [0.12.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.1...pace-rs-v0.12.0) - 2024-03-02

### Added
- add opening documentation on configuration
- *(commands)* [**breaking**] remove only-last option for end and replace --start/--end with --at/-a for setting times

### Fixed
- make sure, there are never any held activities without an active intermission
- *(deps)* update rust crate open to 5.1.0 ([#63](https://github.com/pace-rs/pace/pull/63))

### Other
- reimplement logic to end and activity for in-memory storage to make it easier for error handling
- check if activities to resume is none
- add test for beginning activies on top of held ones
- add comment about use cases still to test via cli
- refactor tests to use results
- use is_future validator for extract_time_or_now to make sure the user doesn't use times laying in the future
- add doc comment to is_endable()
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).