### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.12.0...pace-rs-v0.13.0) - 2024-03-07
+
+### Added
+- *(insights)* export insights to json and temporary html template ([#73](https://github.com/pace-rs/pace/pull/73))
+
+### Fixed
+- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))
+
+### Other
+- *(time)* implement more time based functionality and add more testing ([#71](https://github.com/pace-rs/pace/pull/71))
+- add more debug prints in verbose mode
+- pull out art for easier replacement
+- *(debug)* use tracing and debug! macro to add some more structured logging to pace_core ([#70](https://github.com/pace-rs/pace/pull/70))
+- *(error)* [**breaking**] remove expect/unwrap from codebase ([#69](https://github.com/pace-rs/pace/pull/69))
+- *(deps)* move insta to dev dependencies
+- *(deps)* update rust crate insta to 1.36.1 ([#68](https://github.com/pace-rs/pace/pull/68))
+- *(deps)* update rust crate insta to 1.36.0 ([#66](https://github.com/pace-rs/pace/pull/66))
+
 ## [0.12.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.11.1...pace-rs-v0.12.0) - 2024-03-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "assert_cmd"
@@ -236,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
@@ -254,9 +254,9 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -902,9 +902,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1089,9 +1089,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2588edf622de56e7a1fed57bf203344f63c03f3d43472ba0434a92373c8f27"
+checksum = "68b3fbb0d52bf0cbb5225ba3d2c303aa136031d43abff98284332a9981ecddec"
 dependencies = [
  "is-wsl",
  "libc",
@@ -1145,7 +1145,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "dialoguer",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1492,7 +1492,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2174,9 +2174,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.12.0"
+version = "0.13.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.1...pace_cli-v0.4.2) - 2024-03-07
+
+### Fixed
+- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))
+
+### Other
+- pull out art for easier replacement
+
 ## [0.4.1](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.0...pace_cli-v0.4.1) - 2024-02-29
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.4.1"
+version = "0.4.2"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/pace-rs/pace/compare/pace_core-v0.14.0...pace_core-v0.15.0) - 2024-03-07
+
+### Added
+- *(insights)* export insights to json and temporary html template ([#73](https://github.com/pace-rs/pace/pull/73))
+
+### Fixed
+- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))
+
+### Other
+- *(time)* implement more time based functionality and add more testing ([#71](https://github.com/pace-rs/pace/pull/71))
+- add more debug prints in verbose mode
+- *(debug)* use tracing and debug! macro to add some more structured logging to pace_core ([#70](https://github.com/pace-rs/pace/pull/70))
+- *(error)* [**breaking**] remove expect/unwrap from codebase ([#69](https://github.com/pace-rs/pace/pull/69))
+- *(deps)* update rust crate insta to 1.36.1 ([#68](https://github.com/pace-rs/pace/pull/68))
+- *(deps)* update rust crate insta to 1.36.0 ([#66](https://github.com/pace-rs/pace/pull/66))
+
 ## [0.14.0](https://github.com/pace-rs/pace/compare/pace_core-v0.13.0...pace_core-v0.14.0) - 2024-03-02
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.14.0"
+version = "0.15.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `pace_core`: 0.14.0 -> 0.15.0 (⚠️ API breaking changes)
* `pace-rs`: 0.12.0 -> 0.13.0 (✓ API compatible changes)

### ⚠️ `pace_core` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field ReviewSummary.time_range in /tmp/.tmpvzgT7B/pace/crates/core/src/domain/review.rs:47
  field ReviewSummary.summary_groups_by_category in /tmp/.tmpvzgT7B/pace/crates/core/src/domain/review.rs:53

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_missing.ron

Failed in:
  enum pace_core::ActivityStatusFilter, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/filter.rs:6

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_added.ron

Failed in:
  variant FilteredActivities:TimeRange in /tmp/.tmpvzgT7B/pace/crates/core/src/domain/filter.rs:64

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_missing.ron

Failed in:
  ActivityStore::new, previously in file /tmp/.tmpltaUDm/pace_core/src/service/activity_store.rs:42
  PaceDateTime::is_future, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/time.rs:270
  ReviewSummary::period_start, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::period_end, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::activities_summary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::highlights, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::suggestions, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::set_period_start, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::set_period_end, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::set_activities_summary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::set_highlights, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::set_suggestions, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::period_start_mut, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::period_end_mut, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::activities_summary_mut, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::highlights_mut, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29
  ReviewSummary::suggestions_mut, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:29

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct pace_core::ActivitySummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:60

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_pub_field_missing.ron

Failed in:
  field period_start of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:34
  field period_end of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:37
  field total_time_spent of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:40
  field activities_summary of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:43
  field highlights of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:46
  field suggestions of struct ReviewSummary, previously in file /tmp/.tmpltaUDm/pace_core/src/domain/review.rs:49

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field ReviewSummary.total_time_spent in file /tmp/.tmpvzgT7B/pace/crates/core/src/domain/review.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.2](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.1...pace_cli-v0.4.2) - 2024-03-07

### Fixed
- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))

### Other
- pull out art for easier replacement
</blockquote>

## `pace_core`
<blockquote>

## [0.15.0](https://github.com/pace-rs/pace/compare/pace_core-v0.14.0...pace_core-v0.15.0) - 2024-03-07

### Added
- *(insights)* export insights to json and temporary html template ([#73](https://github.com/pace-rs/pace/pull/73))

### Fixed
- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))

### Other
- *(time)* implement more time based functionality and add more testing ([#71](https://github.com/pace-rs/pace/pull/71))
- add more debug prints in verbose mode
- *(debug)* use tracing and debug! macro to add some more structured logging to pace_core ([#70](https://github.com/pace-rs/pace/pull/70))
- *(error)* [**breaking**] remove expect/unwrap from codebase ([#69](https://github.com/pace-rs/pace/pull/69))
- *(deps)* update rust crate insta to 1.36.1 ([#68](https://github.com/pace-rs/pace/pull/68))
- *(deps)* update rust crate insta to 1.36.0 ([#66](https://github.com/pace-rs/pace/pull/66))
</blockquote>

## `pace-rs`
<blockquote>

## [0.13.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.12.0...pace-rs-v0.13.0) - 2024-03-07

### Added
- *(insights)* export insights to json and temporary html template ([#73](https://github.com/pace-rs/pace/pull/73))

### Fixed
- *(deps)* update rust crate chrono to 0.4.35 ([#72](https://github.com/pace-rs/pace/pull/72))

### Other
- *(time)* implement more time based functionality and add more testing ([#71](https://github.com/pace-rs/pace/pull/71))
- add more debug prints in verbose mode
- pull out art for easier replacement
- *(debug)* use tracing and debug! macro to add some more structured logging to pace_core ([#70](https://github.com/pace-rs/pace/pull/70))
- *(error)* [**breaking**] remove expect/unwrap from codebase ([#69](https://github.com/pace-rs/pace/pull/69))
- *(deps)* move insta to dev dependencies
- *(deps)* update rust crate insta to 1.36.1 ([#68](https://github.com/pace-rs/pace/pull/68))
- *(deps)* update rust crate insta to 1.36.0 ([#66](https://github.com/pace-rs/pace/pull/66))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).