### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.0...pace-rs-v0.13.1) - 2024-03-07
+
+### Fixed
+- *(review)* the table layout for review was broken, this has been fixed now
+
 ## [0.13.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.12.0...pace-rs-v0.13.0) - 2024-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.13.0"
+version = "0.13.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/pace-rs/pace/compare/pace_core-v0.15.0...pace_core-v0.15.1) - 2024-03-07
+
+### Fixed
+- *(review)* the table layout for review was broken, this has been fixed now
+
 ## [0.15.0](https://github.com/pace-rs/pace/compare/pace_core-v0.14.0...pace_core-v0.15.0) - 2024-03-07
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.15.0"
+version = "0.15.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `pace-rs`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.15.1](https://github.com/pace-rs/pace/compare/pace_core-v0.15.0...pace_core-v0.15.1) - 2024-03-07

### Fixed
- *(review)* the table layout for review was broken, this has been fixed now
</blockquote>

## `pace-rs`
<blockquote>

## [0.13.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.0...pace-rs-v0.13.1) - 2024-03-07

### Fixed
- *(review)* the table layout for review was broken, this has been fixed now
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).