### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.1...pace-rs-v0.14.0) - 2024-03-08
+
+### Added
+- *(ux)* warn the user if multiple config files are found and inform that we are using the first in the list.
+- *(config)* [**breaking**] change config fields to use kebab-case and use shorter names for general config. Please rename your old config and regenerate your config with `pace setup config`. Or replace `_` with `-` and rename the following fields accordingly:
+- *(review)* add case-sensitive flag and implement filtering by categories
+- *(review)* split categories into (sub-)categories and deduplicated based on that
+- *(review)* the duration of running activities is taken at the time of the review, so running activities don't show up as 0 duration anymore
+- *(review)* deduplicate activities within a category by description
+- *(commands)* add `setup show` subcommand to show the currently loaded configuration
+- *(insights)* Show amount and duration of intermissions in insights
+
+### Fixed
+- remove warning for no config files in default locations as we already throw an error if so
+- *(ci)* remove logs directory due to failure in ci in release-plz
+
+### Other
+- protect breaking commits in git-cliff
+- fix clippy lints
+- add note about changelog for updates
+- *(deps)* update miette to v7.2.0
+- *(deps)* update dependencies
+- update scoop manifest
+
 ## [0.13.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.0...pace-rs-v0.13.1) - 2024-03-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "dialoguer",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1238,7 +1238,7 @@ version = "0.1.2"
 
 [[package]]
 name = "pace_testing"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "pace_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.13.1"
+version = "0.14.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.2...pace_cli-v0.4.3) - 2024-03-08
+
+### Other
+- fix clippy lints
+
 ## [0.4.2](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.1...pace_cli-v0.4.2) - 2024-03-07
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.4.2"
+version = "0.4.3"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/pace-rs/pace/compare/pace_core-v0.15.1...pace_core-v0.16.0) - 2024-03-08
+
+### Added
+- *(config)* [**breaking**] change config fields to use kebab-case and use shorter names for general config. Please rename your old config and regenerate your config with `pace setup config`. Or replace `_` with `-` and rename the following fields accordingly:
+- *(review)* add case-sensitive flag and implement filtering by categories
+- *(review)* split categories into (sub-)categories and deduplicated based on that
+- *(review)* the duration of running activities is taken at the time of the review, so running activities don't show up as 0 duration anymore
+- *(review)* deduplicate activities within a category by description
+- *(commands)* add `setup show` subcommand to show the currently loaded configuration
+- *(insights)* Show amount and duration of intermissions in insights
+
+### Other
+- fix clippy lints
+- *(deps)* update miette to v7.2.0
+- *(deps)* update dependencies
+
 ## [0.15.1](https://github.com/pace-rs/pace/compare/pace_core-v0.15.0...pace_core-v0.15.1) - 2024-03-07
 
 ### Fixed

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.15.1"
+version = "0.16.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/testing/CHANGELOG.md
+++ b/crates/testing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.1...pace_testing-v0.1.2) - 2024-03-08
+
+### Other
+- fix clippy lints
+
 ## [0.1.1](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.0...pace_testing-v0.1.1) - 2024-03-07
 
 ### Fixed

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_testing"
-version = "0.1.1"
+version = "0.1.2"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `pace_core`: 0.15.1 -> 0.16.0 (⚠️ API breaking changes)
* `pace_testing`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `pace-rs`: 0.13.1 -> 0.14.0 (⚠️ API breaking changes)

### ⚠️ `pace_core` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_missing.ron

Failed in:
  ActivityGroup::root_activity, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:186
  ActivityGroup::intermissions, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:186
  ActivityGroup::new, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:208
  ActivityGroup::add_intermission, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:221
  ActivityGroup::add_multiple_intermissions, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:230

--- failure inherent_method_must_use_added: inherent method #[must_use] added ---

Description:
An inherent method is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_must_use_added.ron

Failed in:
  method pace_core::PaceDateTime::date in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:777
  method pace_core::PaceDateTime::time in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:783
  method pace_core::PaceDateTime::new in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:789
  method pace_core::PaceDateTime::naive_date_time in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:795
  method pace_core::PaceDateTime::now in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:806
  method pace_core::Activity::new_from_self in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:362
  method pace_core::TimeRangeOptions::is_in_range in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:63
  method pace_core::ActivityKindOptions::with_parent_id in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:298
  method pace_core::InMemoryActivityStorage::new_with_activity_log in /tmp/.tmpfvcbfg/pace/crates/core/src/storage/in_memory.rs:63
  method pace_core::ActivityEndOptions::new in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:269
  method pace_core::PaceDate::is_future in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:694
  method pace_core::PaceDate::with_start in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:727
  method pace_core::ActivityKind::to_symbol in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:149
  method pace_core::ReviewSummary::new in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/review.rs:71
  method pace_core::PaceDuration::zero in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:553
  method pace_core::PaceDuration::is_zero in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:558
  method pace_core::PaceDuration::as_secs in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:563
  method pace_core::PaceDuration::as_duration in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:568
  method pace_core::PaceDuration::as_minutes in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:575
  method pace_core::PaceDuration::as_hours in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:582
  method pace_core::PaceDuration::as_days in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:589
  method pace_core::PaceDuration::as_weeks in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:596
  method pace_core::PaceDuration::from_seconds in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/time.rs:601
  method pace_core::ActivityItem::new in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:45
  method pace_core::ActivityItem::into_parts in /tmp/.tmpfvcbfg/pace/crates/core/src/domain/activity.rs:51

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/method_parameter_count_changed.ron

Failed in:
  pace_core::ActivityStore::summary_groups_by_category_for_time_range now takes 3 parameters instead of 2, in /tmp/.tmpfvcbfg/pace/crates/core/src/service/activity_store.rs:102
  pace_core::ActivityTracker::generate_review_summary now takes 3 parameters instead of 2, in /tmp/.tmpfvcbfg/pace/crates/core/src/service/activity_tracker.rs:27

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct pace_core::SummaryGroup, previously in file /tmp/.tmp71aF3X/pace_core/src/domain/review.rs:136
```

### ⚠️ `pace-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_added.ron

Failed in:
  variant SetupSubCmd:Show in /tmp/.tmpfvcbfg/pace/src/commands/setup.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.3](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.2...pace_cli-v0.4.3) - 2024-03-08

### Other
- fix clippy lints
</blockquote>

## `pace_core`
<blockquote>

## [0.16.0](https://github.com/pace-rs/pace/compare/pace_core-v0.15.1...pace_core-v0.16.0) - 2024-03-08

### Added
- *(config)* [**breaking**] change config fields to use kebab-case and use shorter names for general config. Please rename your old config and regenerate your config with `pace setup config`. Or replace `_` with `-` and rename the following fields accordingly:
- *(review)* add case-sensitive flag and implement filtering by categories
- *(review)* split categories into (sub-)categories and deduplicated based on that
- *(review)* the duration of running activities is taken at the time of the review, so running activities don't show up as 0 duration anymore
- *(review)* deduplicate activities within a category by description
- *(commands)* add `setup show` subcommand to show the currently loaded configuration
- *(insights)* Show amount and duration of intermissions in insights

### Other
- fix clippy lints
- *(deps)* update miette to v7.2.0
- *(deps)* update dependencies
</blockquote>

## `pace_testing`
<blockquote>

## [0.1.2](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.1...pace_testing-v0.1.2) - 2024-03-08

### Other
- fix clippy lints
</blockquote>

## `pace-rs`
<blockquote>

## [0.14.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.1...pace-rs-v0.14.0) - 2024-03-08

### Added
- *(ux)* warn the user if multiple config files are found and inform that we are using the first in the list.
- *(config)* [**breaking**] change config fields to use kebab-case and use shorter names for general config. Please rename your old config and regenerate your config with `pace setup config`. Or replace `_` with `-` and rename the following fields accordingly:
- *(review)* add case-sensitive flag and implement filtering by categories
- *(review)* split categories into (sub-)categories and deduplicated based on that
- *(review)* the duration of running activities is taken at the time of the review, so running activities don't show up as 0 duration anymore
- *(review)* deduplicate activities within a category by description
- *(commands)* add `setup show` subcommand to show the currently loaded configuration
- *(insights)* Show amount and duration of intermissions in insights

### Fixed
- remove warning for no config files in default locations as we already throw an error if so
- *(ci)* remove logs directory due to failure in ci in release-plz

### Other
- protect breaking commits in git-cliff
- fix clippy lints
- add note about changelog for updates
- *(deps)* update miette to v7.2.0
- *(deps)* update dependencies
- update scoop manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).