### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.0...pace-rs-v0.14.1) - 2024-03-09
+
+### Added
+- *(ux)* provide a quick start guide post-setup with basic commands and usage tips. ([#11](https://github.com/pace-rs/pace/pull/11))
+
+### Other
+- update testing strategies
+- *(coverage)* don't include unneeded functions in coverage
+- move journey test to integration tests
+- add more snapshot tests for cli
+- remove whitespace to fix codecov badge looking weird
+- add comment about coverage reporting
+- change coverage command in .justfile to run for pace_core, as this contains mostly all logics
+- ignore directories we don't deem important for coverage, such as pace_testing, pace_cli and the slim wrapper around pace_core, which is pace-rs itself.
+- add workspace coverage command to .justfile
+- try coverage build on windows
+- don't use image anymore and install cargo-tarpaulin directly
+- remove xtask from release-plz.toml as well
+- remove nightly from coverage workflow as that seems to break the coverage build
+- migrate xtask tasks to justfile commands
+- *(deps)* add missing chrono feature to diesel
+- cleanup after removing rusqlite and replacing with diesel
+- *(readme)* add codecov badge to readme
+- add code coverage reporting for codecov
+- *(readme)* update state icon of implementation for `review` command
+
 ## [0.14.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.13.1...pace-rs-v0.14.0) - 2024-03-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "dialoguer",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1217,7 +1217,7 @@ version = "0.1.2"
 
 [[package]]
 name = "pace_testing"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "pace_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ similar-asserts = { version = "1.5.0", features = ["serde"] }
 
 [package]
 name = "pace-rs"
-version = "0.14.0"
+version = "0.14.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.3...pace_cli-v0.4.4) - 2024-03-09
+
+### Added
+- *(ux)* provide a quick start guide post-setup with basic commands and usage tips. ([#11](https://github.com/pace-rs/pace/pull/11))
+
 ## [0.4.3](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.2...pace_cli-v0.4.3) - 2024-03-08
 
 ### Other

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.4.3"
+version = "0.4.4"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/pace-rs/pace/compare/pace_core-v0.16.0...pace_core-v0.16.1) - 2024-03-09
+
+### Other
+- move journey test to integration tests
+- *(deps)* add missing chrono feature to diesel
+- cleanup after removing rusqlite and replacing with diesel
+
 ## [0.16.0](https://github.com/pace-rs/pace/compare/pace_core-v0.15.1...pace_core-v0.16.0) - 2024-03-08
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.16.0"
+version = "0.16.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/testing/CHANGELOG.md
+++ b/crates/testing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.2...pace_testing-v0.1.3) - 2024-03-09
+
+### Other
+- *(coverage)* don't include unneeded functions in coverage
+
 ## [0.1.2](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.1...pace_testing-v0.1.2) - 2024-03-08
 
 ### Other

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_testing"
-version = "0.1.2"
+version = "0.1.3"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `pace_core`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `pace_testing`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `pace-rs`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.4](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.3...pace_cli-v0.4.4) - 2024-03-09

### Added
- *(ux)* provide a quick start guide post-setup with basic commands and usage tips. ([#11](https://github.com/pace-rs/pace/pull/11))
</blockquote>

## `pace_core`
<blockquote>

## [0.16.1](https://github.com/pace-rs/pace/compare/pace_core-v0.16.0...pace_core-v0.16.1) - 2024-03-09

### Other
- move journey test to integration tests
- *(deps)* add missing chrono feature to diesel
- cleanup after removing rusqlite and replacing with diesel
</blockquote>

## `pace_testing`
<blockquote>

## [0.1.3](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.2...pace_testing-v0.1.3) - 2024-03-09

### Other
- *(coverage)* don't include unneeded functions in coverage
</blockquote>

## `pace-rs`
<blockquote>

## [0.14.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.0...pace-rs-v0.14.1) - 2024-03-09

### Added
- *(ux)* provide a quick start guide post-setup with basic commands and usage tips. ([#11](https://github.com/pace-rs/pace/pull/11))

### Other
- update testing strategies
- *(coverage)* don't include unneeded functions in coverage
- move journey test to integration tests
- add more snapshot tests for cli
- remove whitespace to fix codecov badge looking weird
- add comment about coverage reporting
- change coverage command in .justfile to run for pace_core, as this contains mostly all logics
- ignore directories we don't deem important for coverage, such as pace_testing, pace_cli and the slim wrapper around pace_core, which is pace-rs itself.
- add workspace coverage command to .justfile
- try coverage build on windows
- don't use image anymore and install cargo-tarpaulin directly
- remove xtask from release-plz.toml as well
- remove nightly from coverage workflow as that seems to break the coverage build
- migrate xtask tasks to justfile commands
- *(deps)* add missing chrono feature to diesel
- cleanup after removing rusqlite and replacing with diesel
- *(readme)* add codecov badge to readme
- add code coverage reporting for codecov
- *(readme)* update state icon of implementation for `review` command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).