### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.1...pace-rs-v0.15.0) - 2024-03-23
+
+### Added
+- *(display)* implement time zone display for activity ([#103](https://github.com/pace-rs/pace/pull/103))
+- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
+- *(commands)* add visible aliases to settings subcommands and remove visible aliases where applicable
+- *(commands)* impl getters and setters for config values
+- *(commands)* add rather bare bones settings command for now
+- add arg-group to make tz args mutually exclusive
+- add timezone args also to other commands
+- set visible aliases
+- *(setup)* implement time zone prompt for setup config
+- *(commands)* rename review to reflect
+- get local time offset
+- *(timezone)* [**breaking**] improves how pace handles timezones
+
+### Fixed
+- *(deps)* update rust crate toml to 0.8.12 ([#99](https://github.com/pace-rs/pace/pull/99))
+- *(deps)* update rust crate diesel to 2.1.5 ([#98](https://github.com/pace-rs/pace/pull/98))
+- *(deps)* update rust crate wildmatch to 2.3.3 ([#95](https://github.com/pace-rs/pace/pull/95))
+- clippy lints
+- *(deps)* update rust crate wildmatch to 2.3.2 ([#94](https://github.com/pace-rs/pace/pull/94))
+- *(deps)* update rust crate thiserror to 1.0.58 ([#93](https://github.com/pace-rs/pace/pull/93))
+- *(deps)* update rust crate wildmatch to 2.3.1 ([#92](https://github.com/pace-rs/pace/pull/92))
+- *(deps)* update rust crate toml to 0.8.11 ([#91](https://github.com/pace-rs/pace/pull/91))
+- *(deps)* update rust crate strum_macros to 0.26.2 ([#86](https://github.com/pace-rs/pace/pull/86))
+- *(deps)* update rust crate strum to 0.26.2 ([#85](https://github.com/pace-rs/pace/pull/85))
+
+### Other
+- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
+- fmt
+- *(release)* commit pace_time changelog
+- update manifests
+- time unit tests
+- date and duration unit tests
+- update cargo-dist
+- let release-plz handle the tags
+- don't run nightly and beta clippy with deny warnings, so we don't fail ci
+- cleanup imports
+- make the future obvious in clippy's name ... :)
+- run clippy-future, but do not fail on us
+- use nextest profiles
+- remove config.toml
+- use msrv to run check
+- remove unneeded paragraph from readme
+- update readme and link to documentation where applicable
+- run valgrind on test suite
+- update cargo install args to use `--locked` to make sure, they build
+
 ## [0.14.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.0...pace-rs-v0.14.1) - 2024-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "assert_cmd"
@@ -157,9 +157,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.70"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d8e92cac0961e91dbd517496b00f7e9b92363dbe6d42c3198268323798860c"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -857,9 +857,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1155,9 +1155,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbb46d5d01695d7a1fb8be5f0d1968bd2b2b8ba1d1b3e7062ce2a0593e57af1"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
  "serde",
@@ -1184,7 +1184,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "pace_cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1267,11 +1267,11 @@ dependencies = [
 
 [[package]]
 name = "pace_server"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "pace_testing"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "pace_core",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "pace_time"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ wildmatch = "2.3.3"
 
 [package]
 name = "pace-rs"
-version = "0.14.1"
+version = "0.15.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.4...pace_cli-v0.4.5) - 2024-03-23
+
+### Added
+- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
+- *(commands)* impl getters and setters for config values
+- *(setup)* implement time zone prompt for setup config
+
+### Other
+- update manifests
+- cleanup imports
+
 ## [0.4.4](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.3...pace_cli-v0.4.4) - 2024-03-09
 
 ### Added

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_cli"
-version = "0.4.4"
+version = "0.4.5"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/pace-rs/pace/compare/pace_core-v0.16.1...pace_core-v0.17.0) - 2024-03-23
+
+### Added
+- *(display)* implement time zone display for activity ([#103](https://github.com/pace-rs/pace/pull/103))
+- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
+- *(commands)* impl getters and setters for config values
+- *(commands)* add rather bare bones settings command for now
+- add arg-group to make tz args mutually exclusive
+- add timezone args also to other commands
+- set visible aliases
+- *(setup)* implement time zone prompt for setup config
+- *(commands)* rename review to reflect
+- get local time offset
+- *(timezone)* [**breaking**] improves how pace handles timezones
+
+### Fixed
+- *(deps)* update rust crate toml to 0.8.12 ([#99](https://github.com/pace-rs/pace/pull/99))
+- *(deps)* update rust crate diesel to 2.1.5 ([#98](https://github.com/pace-rs/pace/pull/98))
+- *(deps)* update rust crate wildmatch to 2.3.3 ([#95](https://github.com/pace-rs/pace/pull/95))
+- clippy lints
+- *(deps)* update rust crate wildmatch to 2.3.2 ([#94](https://github.com/pace-rs/pace/pull/94))
+- *(deps)* update rust crate thiserror to 1.0.58 ([#93](https://github.com/pace-rs/pace/pull/93))
+- *(deps)* update rust crate wildmatch to 2.3.1 ([#92](https://github.com/pace-rs/pace/pull/92))
+- *(deps)* update rust crate toml to 0.8.11 ([#91](https://github.com/pace-rs/pace/pull/91))
+- *(deps)* update rust crate strum_macros to 0.26.2 ([#86](https://github.com/pace-rs/pace/pull/86))
+- *(deps)* update rust crate strum to 0.26.2 ([#85](https://github.com/pace-rs/pace/pull/85))
+
+### Other
+- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
+- update manifests
+- cleanup imports
+
 ## [0.16.1](https://github.com/pace-rs/pace/compare/pace_core-v0.16.0...pace_core-v0.16.1) - 2024-03-09
 
 ### Other

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.16.1"
+version = "0.17.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/server/CHANGELOG.md
+++ b/crates/server/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/pace-rs/pace/compare/pace_server-v0.1.2...pace_server-v0.1.3) - 2024-03-23
+
+### Other
+- update manifests
+
 ## [0.1.2](https://github.com/pace-rs/pace/compare/pace_server-v0.1.1...pace_server-v0.1.2) - 2024-02-28
 
 ### Other

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_server"
-version = "0.1.2"
+version = "0.1.3"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/testing/CHANGELOG.md
+++ b/crates/testing/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.3...pace_testing-v0.2.0) - 2024-03-23
+
+### Added
+- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
+- *(timezone)* [**breaking**] improves how pace handles timezones
+
+### Other
+- update manifests
+- cleanup imports
+
 ## [0.1.3](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.2...pace_testing-v0.1.3) - 2024-03-09
 
 ### Other

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_testing"
-version = "0.1.3"
+version = "0.2.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/time/CHANGELOG.md
+++ b/crates/time/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/pace-rs/pace/compare/pace_time-v0.1.0...pace_time-v0.1.1) - 2024-03-23
+
+### Other
+- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
+
 ## [0.1.0](https://github.com/pace-rs/pace/releases/tag/pace_time-v0.1.0) - 2024-03-22
 
 ### Added

--- a/crates/time/Cargo.toml
+++ b/crates/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_time"
-version = "0.1.0"
+version = "0.1.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_cli`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `pace_core`: 0.16.1 -> 0.17.0 (⚠️ API breaking changes)
* `pace_time`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `pace_testing`: 0.1.3 -> 0.2.0 (✓ API compatible changes)
* `pace_server`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `pace-rs`: 0.14.1 -> 0.15.0 (⚠️ API breaking changes)

### ⚠️ `pace_core` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_missing.ron

Failed in:
  enum pace_core::ActivityLogFormatKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:124
  enum pace_core::IntermissionAction, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/intermission.rs:7
  enum pace_core::ActivityKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:88
  enum pace_core::ActivityStatus, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/status.rs:21
  enum pace_core::PaceErrorKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/error.rs:103
  enum pace_core::FilteredActivities, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/filter.rs:41
  enum pace_core::PaceDurationRange, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:534
  enum pace_core::ActivityLogStorageKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:136
  enum pace_core::StorageKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:61
  enum pace_core::PaceTimeFrame, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:401
  enum pace_core::ActivityFilterKind, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/filter.rs:9

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/function_missing.ron

Failed in:
  function pace_core::get_home_config_path, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:414
  function pace_core::extract_time_or_now, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:487
  function pace_core::get_activity_log_paths, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:345
  function pace_core::overwrite_left_with_right, previously in file /tmp/.tmpcxLiFM/pace_core/src/util.rs:9
  function pace_core::calculate_duration, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:866
  function pace_core::get_config_paths, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:372
  function pace_core::get_home_activity_log_path, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:403
  function pace_core::split_category_by_category_separator, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/category.rs:73
  function pace_core::get_time_frame_from_flags, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:888
  function pace_core::find_root_config_file_path, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:321
  function pace_core::find_root_project_file, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:282
  function pace_core::parse_time_from_user_input, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:518
  function pace_core::duration_to_str, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:443
  function pace_core::get_storage_from_config, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:43

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct pace_core::Highlights, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/review.rs:223
  struct pace_core::DeleteOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands.rs:51
  struct pace_core::UserMessage, previously in file /tmp/.tmpcxLiFM/pace_core/src/error.rs:21
  struct pace_core::ActivityGuid, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:307
  struct pace_core::PaceDateTime, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:772
  struct pace_core::KeywordOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands.rs:56
  struct pace_core::TimeRangeOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:28
  struct pace_core::ResumeCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/resume.rs:13
  struct pace_core::PaceError, previously in file /tmp/.tmpcxLiFM/pace_core/src/error.rs:60
  struct pace_core::ResumeOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/resume.rs:36
  struct pace_core::UpdateOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands.rs:45
  struct pace_core::ActivityTracker, previously in file /tmp/.tmpcxLiFM/pace_core/src/service/activity_tracker.rs:10
  struct pace_core::NowCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/now.rs:13
  struct pace_core::PaceDuration, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:543
  struct pace_core::EndOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands.rs:19
  struct pace_core::GeneralConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:76
  struct pace_core::ExportConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:171
  struct pace_core::PomodoroConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:213
  struct pace_core::InMemoryActivityStorage, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage/in_memory.rs:34
  struct pace_core::HoldOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/hold.rs:88
  struct pace_core::TimeFlags, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/review.rs:178
  struct pace_core::PaceTime, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:754
  struct pace_core::ExpensiveFlags, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/review.rs:157
  struct pace_core::PaceConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:24
  struct pace_core::PaceDate, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/time.rs:690
  struct pace_core::ActivityItem, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:28
  struct pace_core::Activity, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:196
  struct pace_core::InboxConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:246
  struct pace_core::DocsCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/docs.rs:15
  struct pace_core::TomlActivityStorage, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage/file.rs:26
  struct pace_core::ActivityGroup, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:594
  struct pace_core::ActivityKindOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:290
  struct pace_core::ActivityStore, previously in file /tmp/.tmpcxLiFM/pace_core/src/service/activity_store.rs:32
  struct pace_core::ReviewConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:159
  struct pace_core::SummaryActivityGroup, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/review.rs:167
  struct pace_core::FilterOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/filter.rs:92
  struct pace_core::DateFlags, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/review.rs:133
  struct pace_core::AdjustCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/adjust.rs:23
  struct pace_core::HoldCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/hold.rs:16
  struct pace_core::ReviewCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/review.rs:21
  struct pace_core::ReviewSummary, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/review.rs:50
  struct pace_core::BeginCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/begin.rs:15
  struct pace_core::ActivityEndOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:255
  struct pace_core::ActivitySession, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity.rs:535
  struct pace_core::DatabaseConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:201
  struct pace_core::ActivityLog, previously in file /tmp/.tmpcxLiFM/pace_core/src/domain/activity_log.rs:13
  struct pace_core::AutoArchivalConfig, previously in file /tmp/.tmpcxLiFM/pace_core/src/config.rs:261
  struct pace_core::EndCommandOptions, previously in file /tmp/.tmpcxLiFM/pace_core/src/commands/end.rs:17

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/trait_missing.ron

Failed in:
  trait pace_core::SyncStorage, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:83
  trait pace_core::ActivityStorage, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:102
  trait pace_core::ActivityReadOps, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:129
  trait pace_core::ActivityStateManagement, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:239
  trait pace_core::ActivityQuerying, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:424
  trait pace_core::ActivityWriteOps, previously in file /tmp/.tmpcxLiFM/pace_core/src/storage.rs:166
```

### ⚠️ `pace-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_added.ron

Failed in:
  variant PaceCmd:Reflect in /tmp/.tmpSvCSAM/pace/src/commands.rs:66
  variant PaceCmd:Settings in /tmp/.tmpSvCSAM/pace/src/commands.rs:73

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_variant_missing.ron

Failed in:
  variant PaceCmd::Review, previously in file /tmp/.tmpcxLiFM/pace-rs/src/commands.rs:64

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/module_missing.ron

Failed in:
  mod pace_rs::commands::review, previously in file /tmp/.tmpcxLiFM/pace-rs/src/commands/review.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct pace_rs::commands::review::ReviewCmd, previously in file /tmp/.tmpcxLiFM/pace-rs/src/commands/review.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_cli`
<blockquote>

## [0.4.5](https://github.com/pace-rs/pace/compare/pace_cli-v0.4.4...pace_cli-v0.4.5) - 2024-03-23

### Added
- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
- *(commands)* impl getters and setters for config values
- *(setup)* implement time zone prompt for setup config

### Other
- update manifests
- cleanup imports
</blockquote>

## `pace_core`
<blockquote>

## [0.17.0](https://github.com/pace-rs/pace/compare/pace_core-v0.16.1...pace_core-v0.17.0) - 2024-03-23

### Added
- *(display)* implement time zone display for activity ([#103](https://github.com/pace-rs/pace/pull/103))
- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
- *(commands)* impl getters and setters for config values
- *(commands)* add rather bare bones settings command for now
- add arg-group to make tz args mutually exclusive
- add timezone args also to other commands
- set visible aliases
- *(setup)* implement time zone prompt for setup config
- *(commands)* rename review to reflect
- get local time offset
- *(timezone)* [**breaking**] improves how pace handles timezones

### Fixed
- *(deps)* update rust crate toml to 0.8.12 ([#99](https://github.com/pace-rs/pace/pull/99))
- *(deps)* update rust crate diesel to 2.1.5 ([#98](https://github.com/pace-rs/pace/pull/98))
- *(deps)* update rust crate wildmatch to 2.3.3 ([#95](https://github.com/pace-rs/pace/pull/95))
- clippy lints
- *(deps)* update rust crate wildmatch to 2.3.2 ([#94](https://github.com/pace-rs/pace/pull/94))
- *(deps)* update rust crate thiserror to 1.0.58 ([#93](https://github.com/pace-rs/pace/pull/93))
- *(deps)* update rust crate wildmatch to 2.3.1 ([#92](https://github.com/pace-rs/pace/pull/92))
- *(deps)* update rust crate toml to 0.8.11 ([#91](https://github.com/pace-rs/pace/pull/91))
- *(deps)* update rust crate strum_macros to 0.26.2 ([#86](https://github.com/pace-rs/pace/pull/86))
- *(deps)* update rust crate strum to 0.26.2 ([#85](https://github.com/pace-rs/pace/pull/85))

### Other
- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
- update manifests
- cleanup imports
</blockquote>

## `pace_time`
<blockquote>

## [0.1.1](https://github.com/pace-rs/pace/compare/pace_time-v0.1.0...pace_time-v0.1.1) - 2024-03-23

### Other
- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
</blockquote>

## `pace_testing`
<blockquote>

## [0.2.0](https://github.com/pace-rs/pace/compare/pace_testing-v0.1.3...pace_testing-v0.2.0) - 2024-03-23

### Added
- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
- *(timezone)* [**breaking**] improves how pace handles timezones

### Other
- update manifests
- cleanup imports
</blockquote>

## `pace_server`
<blockquote>

## [0.1.3](https://github.com/pace-rs/pace/compare/pace_server-v0.1.2...pace_server-v0.1.3) - 2024-03-23

### Other
- update manifests
</blockquote>

## `pace-rs`
<blockquote>

## [0.15.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.1...pace-rs-v0.15.0) - 2024-03-23

### Added
- *(display)* implement time zone display for activity ([#103](https://github.com/pace-rs/pace/pull/103))
- *(timezone)* improve ux and time zone handling ([#100](https://github.com/pace-rs/pace/pull/100))
- *(commands)* add visible aliases to settings subcommands and remove visible aliases where applicable
- *(commands)* impl getters and setters for config values
- *(commands)* add rather bare bones settings command for now
- add arg-group to make tz args mutually exclusive
- add timezone args also to other commands
- set visible aliases
- *(setup)* implement time zone prompt for setup config
- *(commands)* rename review to reflect
- get local time offset
- *(timezone)* [**breaking**] improves how pace handles timezones

### Fixed
- *(deps)* update rust crate toml to 0.8.12 ([#99](https://github.com/pace-rs/pace/pull/99))
- *(deps)* update rust crate diesel to 2.1.5 ([#98](https://github.com/pace-rs/pace/pull/98))
- *(deps)* update rust crate wildmatch to 2.3.3 ([#95](https://github.com/pace-rs/pace/pull/95))
- clippy lints
- *(deps)* update rust crate wildmatch to 2.3.2 ([#94](https://github.com/pace-rs/pace/pull/94))
- *(deps)* update rust crate thiserror to 1.0.58 ([#93](https://github.com/pace-rs/pace/pull/93))
- *(deps)* update rust crate wildmatch to 2.3.1 ([#92](https://github.com/pace-rs/pace/pull/92))
- *(deps)* update rust crate toml to 0.8.11 ([#91](https://github.com/pace-rs/pace/pull/91))
- *(deps)* update rust crate strum_macros to 0.26.2 ([#86](https://github.com/pace-rs/pace/pull/86))
- *(deps)* update rust crate strum to 0.26.2 ([#85](https://github.com/pace-rs/pace/pull/85))

### Other
- add more tests including journey test ([#102](https://github.com/pace-rs/pace/pull/102))
- fmt
- *(release)* commit pace_time changelog
- update manifests
- time unit tests
- date and duration unit tests
- update cargo-dist
- let release-plz handle the tags
- don't run nightly and beta clippy with deny warnings, so we don't fail ci
- cleanup imports
- make the future obvious in clippy's name ... :)
- run clippy-future, but do not fail on us
- use nextest profiles
- remove config.toml
- use msrv to run check
- remove unneeded paragraph from readme
- update readme and link to documentation where applicable
- run valgrind on test suite
- update cargo install args to use `--locked` to make sure, they build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).