### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.15.0...pace-rs-v0.15.1) - 2024-03-24
+
+### Added
+- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
+- *(commands)* set short version of time zone arguments and case-sensitive
+
+### Other
+- *(deps)* update rust crate rayon to 1.10.0 ([#106](https://github.com/pace-rs/pace/pull/106))
+- update user docs pdf
+- update readme for docs directory
+- add documentation and embed in dist package + add updater command in justfile
+
 ## [0.15.0](https://github.com/pace-rs/pace/compare/pace-rs-v0.14.1...pace-rs-v0.15.0) - 2024-03-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -540,7 +540,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -570,7 +570,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fixedbitset"
@@ -691,7 +691,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1245,7 +1245,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "pace_time"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1452,7 +1452,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1761,7 +1761,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.53",
+ "syn 2.0.55",
  "unicode-ident",
 ]
 
@@ -1856,7 +1856,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2168,7 +2168,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2288,7 +2288,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2358,7 +2358,7 @@ checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2544,7 +2544,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -2566,7 +2566,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ wildmatch = "2.3.3"
 
 [package]
 name = "pace-rs"
-version = "0.15.0"
+version = "0.15.1"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/pace-rs/pace/compare/pace_core-v0.17.0...pace_core-v0.18.0) - 2024-03-24
+
+### Added
+- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
+- *(commands)* set short version of time zone arguments and case-sensitive
+
 ## [0.17.0](https://github.com/pace-rs/pace/compare/pace_core-v0.16.1...pace_core-v0.17.0) - 2024-03-23
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.17.0"
+version = "0.18.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/time/CHANGELOG.md
+++ b/crates/time/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/pace-rs/pace/compare/pace_time-v0.1.1...pace_time-v0.1.2) - 2024-03-24
+
+### Added
+- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
+
 ## [0.1.1](https://github.com/pace-rs/pace/compare/pace_time-v0.1.0...pace_time-v0.1.1) - 2024-03-23
 
 ### Other

--- a/crates/time/Cargo.toml
+++ b/crates/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_time"
-version = "0.1.1"
+version = "0.1.2"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.17.0 -> 0.18.0 (⚠️ API breaking changes)
* `pace_time`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `pace-rs`: 0.15.0 -> 0.15.1 (✓ API compatible changes)

### ⚠️ `pace_core` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ReflectionsFormatKind::Html, previously in file /tmp/.tmpLtFRm2/pace_core/src/domain/reflection.rs:27
  variant ReflectionsFormatKind::Markdown, previously in file /tmp/.tmpLtFRm2/pace_core/src/domain/reflection.rs:31
  variant ReflectionsFormatKind::PlainText, previously in file /tmp/.tmpLtFRm2/pace_core/src/domain/reflection.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.18.0](https://github.com/pace-rs/pace/compare/pace_core-v0.17.0...pace_core-v0.18.0) - 2024-03-24

### Added
- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
- *(commands)* set short version of time zone arguments and case-sensitive
</blockquote>

## `pace_time`
<blockquote>

## [0.1.2](https://github.com/pace-rs/pace/compare/pace_time-v0.1.1...pace_time-v0.1.2) - 2024-03-24

### Added
- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
</blockquote>

## `pace-rs`
<blockquote>

## [0.15.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.15.0...pace-rs-v0.15.1) - 2024-03-24

### Added
- *(template)* implement html and markdown templating for reflections ([#105](https://github.com/pace-rs/pace/pull/105))
- *(commands)* set short version of time zone arguments and case-sensitive

### Other
- *(deps)* update rust crate rayon to 1.10.0 ([#106](https://github.com/pace-rs/pace/pull/106))
- update user docs pdf
- update readme for docs directory
- add documentation and embed in dist package + add updater command in justfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).