### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/pace-rs/pace/compare/pace-rs-v0.15.1...pace-rs-v0.15.2) - 2024-03-24
+
+### Added
+- *(completions)* add nushell completions
+
+### Other
+- remove pace_testing crate and migrate it to integration test ([#108](https://github.com/pace-rs/pace/pull/108))
+- ignore tests that use utc locally and only run them in ci
+
 ## [0.15.1](https://github.com/pace-rs/pace/compare/pace-rs-v0.15.0...pace-rs-v0.15.1) - 2024-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pace-rs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "abscissa_core",
  "assert_cmd",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "pace_core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ wildmatch = "2.3.3"
 
 [package]
 name = "pace-rs"
-version = "0.15.1"
+version = "0.15.2"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/pace-rs/pace/compare/pace_core-v0.18.0...pace_core-v0.19.0) - 2024-03-24
+
+### Other
+- remove pace_testing crate and migrate it to integration test ([#108](https://github.com/pace-rs/pace/pull/108))
+
 ## [0.18.0](https://github.com/pace-rs/pace/compare/pace_core-v0.17.0...pace_core-v0.18.0) - 2024-03-24
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pace_core"
-version = "0.18.0"
+version = "0.19.0"
 authors = { workspace = true }
 categories = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `pace_core`: 0.18.0 -> 0.19.0 (⚠️ API breaking changes)
* `pace-rs`: 0.15.1 -> 0.15.2 (✓ API compatible changes)

### ⚠️ `pace_core` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_missing.ron

Failed in:
  enum pace_core::prelude::ActivityStatus, previously in file /tmp/.tmpsO4JkB/pace_core/src/domain/status.rs:21

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/inherent_method_missing.ron

Failed in:
  Activity::is_held, previously in file /tmp/.tmpsO4JkB/pace_core/src/domain/activity.rs:360
  Activity::is_active, previously in file /tmp/.tmpsO4JkB/pace_core/src/domain/activity.rs:369
  Activity::is_endable, previously in file /tmp/.tmpsO4JkB/pace_core/src/domain/activity.rs:407
  Activity::has_ended, previously in file /tmp/.tmpsO4JkB/pace_core/src/domain/activity.rs:437
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pace_core`
<blockquote>

## [0.19.0](https://github.com/pace-rs/pace/compare/pace_core-v0.18.0...pace_core-v0.19.0) - 2024-03-24

### Other
- remove pace_testing crate and migrate it to integration test ([#108](https://github.com/pace-rs/pace/pull/108))
</blockquote>

## `pace-rs`
<blockquote>

## [0.15.2](https://github.com/pace-rs/pace/compare/pace-rs-v0.15.1...pace-rs-v0.15.2) - 2024-03-24

### Added
- *(completions)* add nushell completions

### Other
- remove pace_testing crate and migrate it to integration test ([#108](https://github.com/pace-rs/pace/pull/108))
- ignore tests that use utc locally and only run them in ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).